### PR TITLE
Limit maximum number of threads to 16.

### DIFF
--- a/crnlib/crn_threading_pthreads.cpp
+++ b/crnlib/crn_threading_pthreads.cpp
@@ -28,9 +28,9 @@ namespace crnlib
 #ifdef WIN32
       SYSTEM_INFO g_system_info;
       GetSystemInfo(&g_system_info);
-      g_number_of_processors = math::maximum<uint>(1U, g_system_info.dwNumberOfProcessors);
+      g_number_of_processors = math::minimum<uint>(16U, math::maximum<uint>(1U, g_system_info.dwNumberOfProcessors));
 #elif defined(__GNUC__)
-      g_number_of_processors = math::maximum<int>(1, get_nprocs());
+      g_number_of_processors = math::minimum<int>(16, math::maximum<int>(1, get_nprocs()));
 #else
       g_number_of_processors = 1;
 #endif


### PR DESCRIPTION
It appears that thread pool does not scale good after this limit. I did not made further research just noticed this is a safe limit. Issues observed during mipmaps generation on 24 threaded CPU.